### PR TITLE
Bug/ai move computation

### DIFF
--- a/src/Engine/Board.java
+++ b/src/Engine/Board.java
@@ -1,7 +1,5 @@
 package Engine;
 
-import java.util.Arrays;
-
 public class Board {
     private Mark[] marks = new Mark[9];
 
@@ -10,7 +8,10 @@ public class Board {
     }
 
     public Board(Board board) {
-        this.marks = Arrays.copyOf(board.marks,board.marks.length);
+        // deep copy due to inner mutation in setMarkAt
+        for (int i = 0; i < board.marks.length; i++) {
+            this.marks[i] = new Mark(i, board.marks[i].symbol());
+        }
     }
     private void initialiseBoard() {
         for (int i = 0; i < 9; i++) {

--- a/src/Engine/Game.java
+++ b/src/Engine/Game.java
@@ -43,7 +43,9 @@ public class Game implements MoveListener {
     }
 
     public void play(Move move) {
-        if (!board.moveIsPossible(move.index())) return;
+        if (!board.moveIsPossible(move.index())) {
+            throw new IllegalArgumentException("Move is not possible, index: " + move.index()+ " is already "+ board.getMarks()[move.index()].symbol());
+        }
         board.setMarkAt(move.index(), move.symbol());
         ui.updateUI(this.board);
         if (board.gameIsOver()) {

--- a/src/Engine/Game.java
+++ b/src/Engine/Game.java
@@ -1,6 +1,6 @@
 package Engine;
 
-import javax.swing.SwingUtilities;
+import javax.swing.SwingWorker;
 
 import Graphics.UI;
 
@@ -27,15 +27,36 @@ public class Game implements MoveListener {
 
     @Override
     public void onMoveSelected(int index) {
-        if (board.gameIsOver()) return;
+        if (board.gameIsOver())
+            return;
         Move recentMove = new Move(index, currentPlayer);
-        play(recentMove);        
+        play(recentMove);
 
-        SwingUtilities.invokeLater(() -> {
-            AI ai = new AI();
-        //Move aiM = ai.getAIMove(this, currentPlayer, AI.MAX_DEPTH); //MAKES GAME STUCK
-        //System.out.println(	aiM.index());
-        });
+        SwingWorker<Move,Void> worker = new SwingWorker<>() {
+            @Override
+            protected Move doInBackground() {
+                System.out.println("AI is thinking...");
+                AI ai = new AI();
+                Move move = ai.getAIMove(Game.this, currentPlayer, AI.MAX_DEPTH);
+                System.out.println("AI is done thinking...");
+                return move;
+            }
+
+            @Override
+            protected void done() {
+                try {
+                    Move aiMove = get();
+                    if (aiMove == null) {
+                        throw new Exception("AI returned null move");
+                    }
+                    System.out.println("AI move: " + aiMove.index());
+                    play(aiMove);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        };
+        worker.execute();
     }
 
     public void start() {


### PR DESCRIPTION
This PR fixes the threaded computation of the AI moves.
By doing so, a bug in the board constructor is fixed.
`Arrays.copy` creates a (deep) copy of the array by cloning each element.
However, the Marks are copied by reference.
The new board references the original Marks.
This leads to errors when `setMarkAt` changes symbols of Marks.

As mentioned in the discourse discussion, the GUI does not freeze.
It handles the moves correctly (at least on my system).
The problem was that
* the move of the AI was never played resulting in no visible change
* the board was silently mutated which together with the silently failing `play` method resulting in no visible change

Additionally, the `play` method was changed to be in compliance with defensive programming.
From the name and semantics, it is expected that this method should play a move.
A silent failure when the move is not possible can be confusing and hides errors (as the one above).
In the case here, the AI would try to play a move on a (silently) changed board and would do nothing as the AI computation has filled the board.
This method should only be called with correct moves. The caller should handle invalid cases or catch errors.

The main fix for the threading problem is to start the computation using a worker thread (SwingWorker does this) and pass the result back to the EDT for taking action (in the `done` method).